### PR TITLE
updated for bsd bash

### DIFF
--- a/bash/.bashrc
+++ b/bash/.bashrc
@@ -27,4 +27,8 @@ pathconcat () {
 }
 
 # path, alias, and other configs
-source "${HOME}"/.bashrc.d/*
+if [ -e "${HOME}"/.bashrc.d/ ] ; then
+  while IFS= read -r -d '' f ; do
+    . "${f}" >/dev/null 2>&1
+  done
+fi


### PR DESCRIPTION
makes more sense when using find to filter config files like this:
```
if [ -e "${HOME}"/.shrc.d/ ] ; then
  . "${HOME}"/.shrc.d/shrc.sh >/dev/null 2>&1
  while IFS= read -r -d '' f ; do
    . "${f}" >/dev/null 2>&1
  done <   <(find "${HOME}"/.shrc.d/* '!' -name 'shrc.sh' -print0)
fi
```