### PR TITLE
Removed unneeded org babel languages

### DIFF
--- a/emacs/.emacs.d/config.org
+++ b/emacs/.emacs.d/config.org
@@ -1583,10 +1583,8 @@ Source code that =org-babel= wants to evaluate
 #+BEGIN_SRC emacs-lisp
 (org-babel-do-load-languages
  'org-babel-load-languages
- '((emacs-lisp . t)
-   (R . t)
+ '((R . t)
    (python . t)
-   (shell . t)
    (latex . t)
    (julia . t)
    (dot . t)


### PR DESCRIPTION
according to https://orgmode.org/worg/org-contrib/babel/languages.html, you do not need (and none exist) for `emacs-lisp` and `shell`